### PR TITLE
feat: enforce stricter typing for Component props

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ For example, the following creates a Node with the following structure:
 
 	const tree = branch({
 		direction: "horizontal",
-		alpha: { component: Window, number: 1 },
+		alpha: { component: Window, props: { number: 1 } },
 		beta: branch({
 			direction: "vertical",
-			alpha: { component: Window, number: 2 },
-			beta: { component: Window, number: 3 }
+			alpha: { component: Window, props: { number: 2 } },
+			beta: { component: Window, props: { number: 3 } }
 		})
 	})
 </script>

--- a/src/lib/Mosaic.svelte
+++ b/src/lib/Mosaic.svelte
@@ -10,14 +10,14 @@
         {#if isTree(tree.alpha)}
             <svelte:self tree={tree.alpha} />
         {:else}
-            <svelte:component this={tree.alpha.component} {...tree.alpha} />
+            <svelte:component this={tree.alpha.component} {...tree.alpha.props} />
         {/if}
     </div>
     <div slot="beta">
         {#if isTree(tree.beta)}
             <svelte:self tree={tree.beta} />
         {:else}
-            <svelte:component this={tree.beta.component} {...tree.beta} />
+            <svelte:component this={tree.beta.component} {...tree.beta.props} />
         {/if}
     </div>
 </Node>

--- a/src/lib/tree.ts
+++ b/src/lib/tree.ts
@@ -1,10 +1,10 @@
-import type { ComponentType, SvelteComponent } from 'svelte';
+import type { ComponentProps, ComponentType, SvelteComponent } from 'svelte';
 
 const treeMarker = Symbol('isTree')
 
-type Component = {
-    [key: string]: unknown,
-    component: ComponentType<SvelteComponent>,
+type Component<T extends SvelteComponent = SvelteComponent> = {
+    props: ComponentProps<T>,
+    component: ComponentType<T>,
 }
 
 export interface Tree {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -8,13 +8,13 @@
 
 	let tree: Tree = branch({
 		direction: "horizontal",
-		alpha: { component: Window, number: 1 },
+		alpha: { component: Window, props: { number: 1 } },
 		alphaSize: [200],
 		betaSize: [200],
 		beta: branch({
 			direction: "vertical",
-			alpha: { component: Window, number: 2 },
-			beta: { component: Window, number: 3 },
+			alpha: { component: Window, props: { number: 2 } },
+			beta: { component: Window, props: { number: 3 } },
 			alphaSize: [250],
 			betaSize: [300]
 		})


### PR DESCRIPTION
I noticed that Component props were being loosely typed, but Svelte has a `ComponentProps` type for enforcing stricter props typing.

While this could have been done like below to keep compatibility
```ts
type Component<T extends SvelteComponent = SvelteComponent> = {
    component: ComponentType<T>,
} & ComponentProps<T>
```
I think it makes more sense to have props in a dedicated object. This is a breaking change, but I think it has a few benefits, listed below. These benefits will also be multiplied if more non-Svelte props are added to the type of Component.
- It makes it clearer which props are being used by svelte-mosaic and which are being used by the Svelte component
- It allows the Svelte component to have a prop named "component" without conflicting to the non-Svelte prop by the same name
- It removes the warning given by Svelte for passing the "component" prop to Svelte components which don't export such a prop
  > \<Component> was created with unknown prop 'component'

  This could also be fixed by, in Mosaic and with alpha as an example, doing
  ```ts
  const { alphaComponent, ...alphaProps } = tree.alpha;
  ```
  ```html
  <svelte:component this={alphaComponent} {...alphaProps} />
  ```